### PR TITLE
Stopgap fix for REPL autocomplete breaking

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -161,7 +161,7 @@ soft_reset:
 
 void app_main(void) {
     nvs_flash_init();
-    xTaskCreate(mp_task, "mp_task", MP_TASK_STACK_LEN, NULL, MP_TASK_PRIORITY, &mp_main_task_handle);
+    xTaskCreatePinnedToCore(mp_task, "mp_task", MP_TASK_STACK_LEN, NULL, MP_TASK_PRIORITY, &mp_main_task_handle, MICROPY_REPL_CORE );
 }
 
 void nlr_jump_fail(void *val) {

--- a/ports/esp32/modmultipython.c
+++ b/ports/esp32/modmultipython.c
@@ -446,9 +446,6 @@ mp_obj_t execute_from_str(const char *str) {
 }
 
 void multipython_task_template( void* void_context ){
-
-    printf("hello from task. On core %d\n", xPortGetCoreID() ); //xPortGetCoreID()
-
     // when a new task spawns it already has a context allocated, but
     // it is up to the task to set the context id correctly
     mp_context_node_t* context = (mp_context_node_t*)void_context;

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -8,6 +8,7 @@
 // multi-core configuration
 #define MICROPY_NUM_CORES                   (2)
 #define MICROPY_GET_CORE_INDEX              (xPortGetCoreID())
+#define MICROPY_REPL_CORE                   (1)
 
 // object representation and NLR handling
 #define MICROPY_OBJ_REPR                    (MICROPY_OBJ_REPR_A)

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -154,8 +154,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_sys_getsizeof_obj, mp_sys_getsizeof);
 STATIC const mp_rom_map_elem_t mp_module_sys_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_sys) },
 
-    { MP_ROM_QSTR(MP_QSTR_path), MP_ROM_PTR(&mp_active_sys_path_objs[0]) },
-    { MP_ROM_QSTR(MP_QSTR_argv), MP_ROM_PTR(&mp_active_sys_argv_objs[0]) },
+    { MP_ROM_QSTR(MP_QSTR_path), MP_ROM_PTR(&mp_active_sys_path_objs[MICROPY_REPL_CORE]) },
+    { MP_ROM_QSTR(MP_QSTR_argv), MP_ROM_PTR(&mp_active_sys_argv_objs[MICROPY_REPL_CORE]) },
     { MP_ROM_QSTR(MP_QSTR_version), MP_ROM_PTR(&version_obj) },
     { MP_ROM_QSTR(MP_QSTR_version_info), MP_ROM_PTR(&mp_sys_version_info_obj) },
     { MP_ROM_QSTR(MP_QSTR_implementation), MP_ROM_PTR(&mp_sys_implementation_obj) },
@@ -192,7 +192,7 @@ STATIC const mp_rom_map_elem_t mp_module_sys_globals_table[] = {
     #endif
 
     #if MICROPY_PY_SYS_MODULES
-    { MP_ROM_QSTR(MP_QSTR_modules), MP_ROM_PTR(&mp_active_loaded_modules_dicts[0]) },
+    { MP_ROM_QSTR(MP_QSTR_modules), MP_ROM_PTR(&mp_active_loaded_modules_dicts[MICROPY_REPL_CORE]) },
     #endif
     #if MICROPY_PY_SYS_EXC_INFO
     { MP_ROM_QSTR(MP_QSTR_exc_info), MP_ROM_PTR(&mp_sys_exc_info_obj) },

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -119,6 +119,10 @@
 #define MICROPY_GET_CORE_INDEX (0)
 #endif
 
+#ifndef MICROPY_REPL_CORE
+#define MICROPY_REPL_CORE (0)
+#endif
+
 /*****************************************************************************/
 /* Memory allocation policy                                                  */
 

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -54,7 +54,7 @@
 mp_obj_dict_t mp_active_dict_mains[MICROPY_NUM_CORES];
 const mp_obj_module_t mp_module___main__ = {
     .base = { &mp_type_module },
-    .globals = (mp_obj_dict_t*)&mp_active_dict_mains[0],
+    .globals = (mp_obj_dict_t*)&mp_active_dict_mains[MICROPY_REPL_CORE],
 };
 
 void mp_init(void) {


### PR DESCRIPTION
Fixes REPL autocomplete by pinning the main (REPL) task to a single core, thus ensuring that the mirror variables always point at the REPL state. Also removes an unsightly print statement